### PR TITLE
Upgrade frontend dev deps node v10.15.3 and yarn v1.15.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,16 +2,20 @@ include config.mk
 
 DESTINATION=${REPO}/${IMAGE}
 
-all: opt build push git
-base: opt build-base push-base git-base
-dev: opt build-dev push-dev git-dev
-ci: opt build-ci push-ci git-ci
+.DEFAULT_GOAL := default
+
+default: build
 
 opt:
 	@echo "build options:"
 	@echo "  REPO    = ${REPO}"
 	@echo "  IMAGE   = ${IMAGE}"
 	@echo "  VERSION = ${VERSION}"
+
+all: opt build push git
+base: opt build-base push-base git-base
+dev: opt build-dev push-dev git-dev
+ci: opt build-ci push-ci git-ci
 
 build: build-base build-dev build-ci
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+## Development Workflow
+
+### Local Dev
+
+1. Create new branch off of `origin/master` to make your changes
+2. Make changes to Dockerfiles and update [`config.mk`](http://config.mk) file with new version
+3. Build all images: `make build`
+4. Test images using Docker locally. You can use one of the following commands to get a bash shell:
+    - base image
+      ```sh
+      docker run -it uptrend/base-elixir:base-1.2.0 /bin/bash
+      ```
+    - dev image
+      ```sh
+      docker run -it uptrend/base-elixir:dev-1.2.0 /bin/bash
+      ```
+    - ci image
+      ```
+      docker run -it uptrend/base-elixir:ci-1.2.0 /bin/bash
+      ```
+
+When you're ready to release a new version create and merge PR to master.
+
+### Deploy Docker Images
+Do this after your PR is merged into master.
+1. Pull `origin/master` locally
+2. Run `make all`

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,6 +1,6 @@
 FROM bitwalker/alpine-elixir:1.8.0
 
-ENV REFRESHED_AT=2019-02-18
+ENV REFRESHED_AT=2019-04-17
 
 LABEL maintainer="brandon@uptrend.tech"
 
@@ -8,14 +8,16 @@ RUN apk --no-cache add  libcrypto1.0 libssl1.0
 
 RUN \
   sed -i 's/v3.8/v3.9/g' /etc/apk/repositories && \
-  echo "@edgetesting http://nl.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories && \
+  # Add pinned repos for access to newer packages. More info: https://bit.ly/2PfS8K0
+  echo "@edge http://nl.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories && \
+  echo "@edgecommunity http://nl.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories && \
   apk upgrade && \
   apk --no-cache add \
-  # Distillery needs bash now
-  bash \
-  # Used to fetch EC2 instance IP before launch. Busybox provides wget, but
-  # it requires openssl, which is a bigger install
-  curl
+    # Distillery needs bash now
+    bash \
+    # Used to fetch EC2 instance IP before launch. Busybox provides wget, but
+    # it requires openssl, which is a bigger install
+    curl
 
 # Install wkhtmltopdf
 # copies static binary from docker image and install it's dependencys

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,6 +1,6 @@
-FROM uptrend/base-elixir:dev-1.1.0
+FROM uptrend/base-elixir:dev-1.2.0
 
-ENV REFRESHED_AT=2019-02-18
+ENV REFRESHED_AT=2019-04-17
 
 LABEL maintainer="brandon@uptrend.tech"
 

--- a/config.mk
+++ b/config.mk
@@ -1,3 +1,3 @@
 REPO=uptrend
 IMAGE=base-elixir
-VERSION=1.1.0
+VERSION=1.2.0

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -1,6 +1,6 @@
-FROM uptrend/base-elixir:1.1.0
+FROM uptrend/base-elixir:1.2.0
 
-ENV REFRESHED_AT=2019-02-18
+ENV REFRESHED_AT=2019-04-17
 
 LABEL maintainer="brandon@uptrend.tech"
 
@@ -18,8 +18,8 @@ RUN \
     make \
     g++ \
     grep \
-    nodejs \
-    yarn \
+    nodejs@edge \
+    yarn@edgecommunity \
     inotify-tools \
   && \
   update-ca-certificates --fresh && \


### PR DESCRIPTION
This PR does **NOT** change Elixir version. It only updates node and yarn.
 
## Overview of changes
- Update Makefile to prevent accidental image deploy
- Upgrade to node v10.15.3 and yarn v1.15.2
  - Update Makefile so running `make` only builds images
  - Added apk tagged repositories @edge / @edgecommunity
  - Update apk installs to use tagged repos nodejs@edge & yarn@edgecommunity
- Add README with dev workflow suggestions